### PR TITLE
Add loading screen for appliance manager

### DIFF
--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -826,9 +826,11 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         self.geometry("400x200")
         self.resizable(False, False)
 
-        # container frame packed to avoid geometry manager conflicts
+        # Container frame managed by grid for consistent layout
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
         self.container = ctk.CTkFrame(self)
-        self.container.pack(fill="both", expand=True)
+        self.container.grid(row=0, column=0, sticky="nsew")
         self.container.rowconfigure(0, weight=1)
         self.container.columnconfigure(0, weight=1)
 

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -826,17 +826,19 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         self.geometry("400x200")
         self.resizable(False, False)
 
-        # ensure layout uses grid so we don't mix managers
-        self.rowconfigure(0, weight=1)
-        self.columnconfigure(0, weight=1)
+        # container frame packed to avoid geometry manager conflicts
+        self.container = ctk.CTkFrame(self)
+        self.container.pack(fill="both", expand=True)
+        self.container.rowconfigure(0, weight=1)
+        self.container.columnconfigure(0, weight=1)
 
-        loader = LoadingFrame(self)
+        loader = LoadingFrame(self.container)
         loader.grid(row=0, column=0, sticky="nsew")
         loader.start()
         self.update_idletasks()
 
         # Perform heavy initialization
-        self.app = ApplianceManagerApp(self)
+        self.app = ApplianceManagerApp(self.container)
 
         loader.stop()
         loader.destroy()

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -826,8 +826,12 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         self.geometry("400x200")
         self.resizable(False, False)
 
+        # ensure layout uses grid so we don't mix managers
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
+
         loader = LoadingFrame(self)
-        loader.pack(expand=True, fill="both")
+        loader.grid(row=0, column=0, sticky="nsew")
         loader.start()
         self.update_idletasks()
 
@@ -840,10 +844,6 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         # Final window size
         self.geometry("1400x800")
         self.minsize(1000, 600)
-
-        # Configure window layout
-        self.rowconfigure(0, weight=1)
-        self.columnconfigure(0, weight=1)
 
         # Center window
         self.after(10, self._center_window)

--- a/app.log
+++ b/app.log
@@ -34,3 +34,21 @@
 2025-06-30 12:49:47,772 - ApplianceManagerFrame - INFO - Added IKE844 to cart
 2025-06-30 12:51:12,537 - ApplianceManagerFrame - INFO - Added FSE725 to cart
 2025-06-30 12:51:22,188 - ApplianceManagerFrame - INFO - Added OVN7000 to cart
+2025-07-03 11:37:43,611 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 11:37:43,653 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 11:42:00,793 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 11:42:00,829 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 11:42:36,651 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 11:42:36,685 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 12:03:22,604 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 12:03:22,637 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 12:03:35,573 - ApplianceManagerFrame - INFO - Application initialized successfully
+2025-07-03 12:03:52,752 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 12:03:52,791 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 12:04:05,730 - ApplianceManagerFrame - INFO - Application initialized successfully
+2025-07-03 12:11:48,374 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 12:11:48,409 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 12:12:01,880 - ApplianceManagerFrame - INFO - Application initialized successfully
+2025-07-03 12:16:32,362 - ApplianceManagerFrame - INFO - Loaded 8 electrical blocks
+2025-07-03 12:16:32,396 - ApplianceManagerFrame - INFO - Loaded 1170 appliances
+2025-07-03 12:16:45,804 - ApplianceManagerFrame - INFO - Application initialized successfully

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Alle andere functionaliteit blijft ongewijzigd.
 
 from pathlib import Path
 from tkinter import messagebox
+import tkinter as tk
 from typing import Tuple
 
 import customtkinter as ctk
@@ -63,6 +64,8 @@ class IxinaToolsApp(ctk.CTk):
 
     def __init__(self) -> None:  # noqa: D401
         super().__init__()
+        self.icon_image = tk.PhotoImage(file=LOGO_IMAGE_PATH)
+        self.iconphoto(False, self.icon_image)
         self.title(TITLE)
         self.minsize(900, 300)
 


### PR DESCRIPTION
## Summary
- show Ixina logo as application icon
- add a small loading screen with a progress bar when ApplianceManagerWindow opens

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b54dd2508320869f3f66fc5f0b85