### PR TITLE
Fix loader progress display

### DIFF
--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -834,7 +834,7 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         loader = LoadingFrame(self)
         loader.grid(row=0, column=0, sticky="nsew")
         loader.start()
-        self.update_idletasks()
+        self.update()
 
         # Perform heavy initialization
         self.app = ApplianceManagerApp(self)

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -826,18 +826,23 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         self.geometry("400x200")
         self.resizable(False, False)
 
-        # Use grid layout for all contents
+        # Use a container so loader and main app share the same geometry manager
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
 
-        # Display loader directly inside the window
-        loader = LoadingFrame(self)
+        self.container = ctk.CTkFrame(self)
+        self.container.grid(row=0, column=0, sticky="nsew")
+        self.container.rowconfigure(0, weight=1)
+        self.container.columnconfigure(0, weight=1)
+
+        # Display loader inside the container
+        loader = LoadingFrame(self.container)
         loader.grid(row=0, column=0, sticky="nsew")
         loader.start()
         self.update()
 
         # Perform heavy initialization
-        self.app = ApplianceManagerApp(self)
+        self.app = ApplianceManagerApp(self.container)
 
         loader.stop()
         loader.destroy()

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -16,8 +16,11 @@ from pathlib import Path
 from typing import Dict, List, Optional, Protocol, Callable, Any
 from functools import lru_cache
 import customtkinter as ctk
+import tkinter as tk
 from PIL import Image, ImageDraw, ImageOps, ImageFont
 
+BASE_DIR = Path(__file__).parent
+LOGO_IMAGE_PATH = BASE_DIR / "logo.png"
 
 # ============================================================================
 # Configuration and Constants
@@ -787,22 +790,62 @@ class ApplianceManagerApp(ctk.CTkFrame):
 # Application Window
 # ============================================================================
 
+class LoadingFrame(ctk.CTkFrame):
+    """Simple loading screen with progress bar and logo."""
+
+    def __init__(self, master: ctk.CTk):
+        super().__init__(master)
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure((0, 1, 2), weight=1)
+
+        logo_img = ctk.CTkImage(Image.open(LOGO_IMAGE_PATH), size=(150, 45))
+        ctk.CTkLabel(self, image=logo_img, text="").grid(row=0, column=0, pady=(20, 10))
+        ctk.CTkLabel(self, text="Toestellenmanager laden...", font=("Helvetica", 16)).grid(row=1, column=0)
+
+        self.progress = ctk.CTkProgressBar(self, mode="indeterminate")
+        self.progress.grid(row=2, column=0, sticky="ew", padx=40, pady=(10, 20))
+
+    def start(self):
+        self.progress.start()
+
+    def stop(self):
+        self.progress.stop()
+
+
 class ApplianceManagerWindow(ctk.CTkToplevel):
     """Main application window."""
 
     def __init__(self, master: ctk.CTk = None):
         super().__init__(master)
+        self.icon_image = tk.PhotoImage(file=LOGO_IMAGE_PATH)
+        self.iconphoto(False, self.icon_image)
 
         self.title("Ixina Toestellenmanager v2.0")
-        self.geometry("1400x800")
-        self.minsize(1000, 600)
 
-        # Configure window layout
+        # Temporary small window while loading
+        self.geometry("400x200")
+        self.resizable(False, False)
+
+        # Use grid layout for all contents
         self.rowconfigure(0, weight=1)
         self.columnconfigure(0, weight=1)
 
-        # Create main app frame
+        # Display loader directly inside the window
+        loader = LoadingFrame(self)
+        loader.grid(row=0, column=0, sticky="nsew")
+        loader.start()
+        self.update_idletasks()
+
+        # Perform heavy initialization
         self.app = ApplianceManagerApp(self)
+
+        loader.stop()
+        loader.destroy()
+
+        # Final window size
+        self.geometry("1400x800")
+        self.minsize(1000, 600)
+        self.resizable(True, True)
 
         # Center window
         self.after(10, self._center_window)

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Alle andere functionaliteit blijft ongewijzigd.
 
 from pathlib import Path
 from tkinter import messagebox
+import tkinter as tk
 from typing import Tuple
 
 import customtkinter as ctk
@@ -63,6 +64,8 @@ class IxinaToolsApp(ctk.CTk):
 
     def __init__(self) -> None:  # noqa: D401
         super().__init__()
+        self.icon_image = tk.PhotoImage(file=LOGO_IMAGE_PATH)
+        self.iconphoto(False, self.icon_image)
         self.title(TITLE)
         self.minsize(900, 300)
 


### PR DESCRIPTION
## Summary
- use loader directly in the window so the main frame fills the space
- show progress bar by calling `update_idletasks()` before heavy init

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862b54dd2508320869f3f66fc5f0b85