### PR TITLE
Refactor image cache and add unit tests

### DIFF
--- a/tests/test_appliance_manager.py
+++ b/tests/test_appliance_manager.py
@@ -1,0 +1,62 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ApplianceManagerFrame import Appliance, ShoppingCart, ApplianceFilter
+
+
+def test_appliance_from_dict():
+    data = {
+        'code': 'TEST001',
+        'brand': 'TestBrand',
+        'category': 'oven',
+        'punten': 50,
+        'price_ex': 499.99,
+        'option': 'met pyrolyse',
+        'img': 'test.jpg'
+    }
+
+    appliance = Appliance.from_dict(data)
+    assert appliance.code == 'TEST001'
+    assert appliance.points == 50
+    assert appliance.price_ex == 499.99
+
+
+def test_shopping_cart():
+    cart = ShoppingCart()
+    appliance = Appliance('TEST001', 'TestBrand', 'oven', 50, 499.99)
+
+    cart.add_item(appliance)
+    assert len(cart.items) == 1
+    assert cart.get_total_points() == 50
+
+    cart.add_item(appliance)
+    assert len(cart.items) == 1
+    assert cart.items[0].quantity == 2
+    assert cart.get_total_points() == 100
+
+    cart.remove_item(appliance)
+    assert len(cart.items) == 0
+    assert cart.get_total_points() == 0
+
+
+def test_appliance_filter():
+    appliances = [
+        Appliance('OVEN001', 'Siemens', 'oven', 60, 599.99),
+        Appliance('KOOK001', 'Bosch', 'kookplaat', 40, 399.99),
+        Appliance('VAAS001', 'Miele', 'vaatwasser', 80, 799.99)
+    ]
+
+    filter_obj = ApplianceFilter(appliances)
+
+    ovens = filter_obj.filter(category='oven')
+    assert len(ovens) == 1
+    assert ovens[0].code == 'OVEN001'
+
+    low_points = filter_obj.filter(max_points=50)
+    assert len(low_points) == 1
+
+    siemens = filter_obj.filter(brand='Siemens')
+    assert len(siemens) == 1
+    assert siemens[0].brand == 'Siemens'


### PR DESCRIPTION
## Summary
- Replace `ImageCache`'s `lru_cache` with an explicit `OrderedDict` LRU to respect configurable cache limits
- Move embedded examples into `tests/` and adjust expectations for point filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cb19dfd848320aec3e764a26ef7bb