### PR TITLE
Fix GUI layout spacing

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,9 +69,14 @@ class IxinaToolsApp(ctk.CTk):
         self.title(TITLE)
         self.minsize(900, 300)
 
-        self.columnconfigure((0, 1, 2, 3), weight=1)
-        # Plaats de grid-inhoud steeds bovenaan wanneer het venster groter wordt
-        self.grid_anchor("n")
+        # Plaats alle inhoud in een aparte frame die bovenaan verankerd wordt
+        # zodat er geen grote lege ruimte bovenaan het venster verschijnt.
+        self.main_frame = ctk.CTkFrame(self, fg_color="transparent")
+        self.main_frame.pack(side="top", fill="both", expand=True)
+        self.main_frame.grid_anchor("n")
+        self.main_frame.grid_columnconfigure((0, 1, 2, 3), weight=1)
+        # Lege rij onderaan die overtollige ruimte opvangt
+        self.main_frame.grid_rowconfigure(3, weight=1)
 
         self._create_header_section()
         self._create_button_section()
@@ -82,23 +87,26 @@ class IxinaToolsApp(ctk.CTk):
 
     def _create_header_section(self) -> None:
         logo_img = load_ctk_image(LOGO_IMAGE_PATH, size=(150, 45))
-        ctk.CTkLabel(self, image=logo_img, text="").grid(
+        ctk.CTkLabel(self.main_frame, image=logo_img, text="").grid(
             row=0, column=0, padx=20, pady=(20, 5), sticky="nw"
         )
-        ctk.CTkLabel(self, text=LABEL_TEXT, font=("Helvetica", 24, "bold"), anchor="center").grid(
-            row=0, column=1, columnspan=3, pady=20
-        )
-        ctk.CTkLabel(self, text=AUTHOR, font=("Helvetica", 12)).grid(
+        ctk.CTkLabel(
+            self.main_frame,
+            text=LABEL_TEXT,
+            font=("Helvetica", 24, "bold"),
+            anchor="center",
+        ).grid(row=0, column=1, columnspan=3, pady=20)
+        ctk.CTkLabel(self.main_frame, text=AUTHOR, font=("Helvetica", 12)).grid(
             row=1, column=0, sticky="w", padx=20
         )
-        ctk.CTkLabel(self, text=VERSION, font=("Helvetica", 12)).grid(
+        ctk.CTkLabel(self.main_frame, text=VERSION, font=("Helvetica", 12)).grid(
             row=1, column=3, sticky="e", padx=20
         )
 
     def _create_button_section(self) -> None:
         font_cfg = ("Helvetica", 15)
         for idx, label in enumerate(BUTTON_LABELS, start=1):
-            frame = ctk.CTkFrame(self, width=280, height=150)
+            frame = ctk.CTkFrame(self.main_frame, width=280, height=150)
             frame.grid(row=2, column=idx, padx=15, pady=20, sticky="nsew")
             frame.rowconfigure(0, weight=1)
             frame.columnconfigure(0, weight=1)

--- a/main.py
+++ b/main.py
@@ -70,9 +70,8 @@ class IxinaToolsApp(ctk.CTk):
         self.minsize(900, 300)
 
         self.columnconfigure((0, 1, 2, 3), weight=1)
-        # Gebruik een lege rij onder de knoppen zodat alle inhoud
-        # tegen de bovenkant van het venster blijft staan.
-        self.rowconfigure(3, weight=1)
+        # Plaats de grid-inhoud steeds bovenaan wanneer het venster groter wordt
+        self.grid_anchor("n")
 
         self._create_header_section()
         self._create_button_section()

--- a/main.py
+++ b/main.py
@@ -70,7 +70,9 @@ class IxinaToolsApp(ctk.CTk):
         self.minsize(900, 300)
 
         self.columnconfigure((0, 1, 2, 3), weight=1)
-        self.rowconfigure(2, weight=1)
+        # Gebruik een lege rij onder de knoppen zodat alle inhoud
+        # tegen de bovenkant van het venster blijft staan.
+        self.rowconfigure(3, weight=1)
 
         self._create_header_section()
         self._create_button_section()

--- a/main.py
+++ b/main.py
@@ -69,13 +69,17 @@ class IxinaToolsApp(ctk.CTk):
         self.title(TITLE)
         self.minsize(900, 300)
 
-        # Plaats alle inhoud in een aparte frame die bovenaan verankerd wordt
-        # zodat er geen grote lege ruimte bovenaan het venster verschijnt.
+        # Gebruik een grid‑indeling op het hoofdvenster zodat het beschikbare
+        # schermoppervlak zich onder de inhoud bevindt i.p.v. erboven.
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(1, weight=1)  # lege rij onderaan
+
+        # Plaats alle GUI‑elementen in een frame dat in de bovenste rij staat.
         self.main_frame = ctk.CTkFrame(self, fg_color="transparent")
-        self.main_frame.pack(side="top", fill="both", expand=True)
+        self.main_frame.grid(row=0, column=0, sticky="new")
         self.main_frame.grid_anchor("n")
         self.main_frame.grid_columnconfigure((0, 1, 2, 3), weight=1)
-        # Lege rij onderaan die overtollige ruimte opvangt
+        # Lege rij onderaan die overtollige ruimte opvangt binnen het frame
         self.main_frame.grid_rowconfigure(3, weight=1)
 
         self._create_header_section()


### PR DESCRIPTION
## Summary
- Ensure main menu components sit at the top of the window by adding a stretchable bottom row.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688cc33571bc832098f1492ac2cfda75