### PR TITLE
Fix main frame positioning after loading

### DIFF
--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -947,6 +947,9 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         loader.stop()
         loader.destroy()
 
+        # ensure main application fills the window from the top
+        self.app.grid(row=0, column=0, sticky="nsew")
+
         # Final window size
         self.geometry("1400x800")
         self.minsize(1000, 600)


### PR DESCRIPTION
## Summary
- Ensure ApplianceManagerApp fills the window by regridding it after the loading screen is removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df50737108320a6826b91d7a364ea