### PR TITLE
Improve appliance manager loading and cart updates

### DIFF
--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -86,7 +86,6 @@ except ModuleNotFoundError:  # pragma: no cover - allow headless use
         CTkSwitch = _DummyWidget
         CTkScrollableFrame = _DummyWidget
         CTkToplevel = _DummyWidget
-        CTkProgressBar = _DummyWidget
         CTkImage = _DummyImage
         StringVar = _DummyVar
         DoubleVar = _DummyVar
@@ -911,7 +910,7 @@ class ApplianceManagerApp(ctk.CTkFrame):
 # ============================================================================
 
 class SplashScreen(ctk.CTkToplevel):
-    """Centered splash screen with logo and progress bar."""
+    """Centered splash screen with logo."""
 
     def __init__(self, master: ctk.CTk):
         super().__init__(master)
@@ -920,17 +919,13 @@ class SplashScreen(ctk.CTkToplevel):
         self.configure(fg_color="#2b2b2b")
 
         self.columnconfigure(0, weight=1)
-        self.rowconfigure((0, 1, 2, 3), weight=1)
+        self.rowconfigure((0, 1, 2), weight=1)
 
         logo_img = ctk.CTkImage(Image.open(LOGO_IMAGE_PATH), size=(200, 70))
         ctk.CTkLabel(self, image=logo_img, text="").grid(row=0, column=0, pady=(60, 10))
         ctk.CTkLabel(self, text="Laden...", font=ctk.CTkFont(size=16)).grid(
-            row=1, column=0, pady=(0, 10)
+            row=1, column=0, pady=(0, 60)
         )
-
-        self.progress = ctk.CTkProgressBar(self, height=8, mode="indeterminate")
-        self.progress.grid(row=2, column=0, sticky="ew", padx=80, pady=(0, 60))
-        self.progress.start()
 
         self.after(10, self._center)
 
@@ -944,11 +939,7 @@ class SplashScreen(ctk.CTkToplevel):
         self.geometry(f"{width}x{height}+{x}+{y}")
 
     def close(self):
-        """Stop animation and destroy splash."""
-        try:
-            self.progress.stop()
-        except Exception:
-            pass
+        """Destroy splash."""
         self.destroy()
 
 

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -928,10 +928,9 @@ class SplashScreen(ctk.CTkToplevel):
             row=1, column=0, pady=(0, 10)
         )
 
-        self.progress = ctk.CTkProgressBar(self, height=8)
+        self.progress = ctk.CTkProgressBar(self, height=8, mode="indeterminate")
         self.progress.grid(row=2, column=0, sticky="ew", padx=80, pady=(0, 60))
-        self._progress_value = 0.0
-        self._animate_job = self.after(0, self._animate)
+        self.progress.start()
 
         self.after(10, self._center)
 
@@ -944,16 +943,12 @@ class SplashScreen(ctk.CTkToplevel):
         y = (self.winfo_screenheight() - height) // 2
         self.geometry(f"{width}x{height}+{x}+{y}")
 
-    def _animate(self):
-        """Continuously animate the progress bar."""
-        self._progress_value = (self._progress_value + 0.02) % 1.0
-        self.progress.set(self._progress_value)
-        self._animate_job = self.after(20, self._animate)
-
     def close(self):
         """Stop animation and destroy splash."""
-        if getattr(self, "_animate_job", None):
-            self.after_cancel(self._animate_job)
+        try:
+            self.progress.stop()
+        except Exception:
+            pass
         self.destroy()
 
 

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -924,13 +924,14 @@ class SplashScreen(ctk.CTkToplevel):
 
         logo_img = ctk.CTkImage(Image.open(LOGO_IMAGE_PATH), size=(200, 70))
         ctk.CTkLabel(self, image=logo_img, text="").grid(row=0, column=0, pady=(60, 10))
-        ctk.CTkLabel(self, text="Loading...", font=ctk.CTkFont(size=16)).grid(
+        ctk.CTkLabel(self, text="Laden...", font=ctk.CTkFont(size=16)).grid(
             row=1, column=0, pady=(0, 10)
         )
 
-        self.progress = ctk.CTkProgressBar(self, mode="indeterminate", height=8)
+        self.progress = ctk.CTkProgressBar(self, height=8)
         self.progress.grid(row=2, column=0, sticky="ew", padx=80, pady=(0, 60))
-        self.progress.start()
+        self._progress_value = 0.0
+        self._animate_job = self.after(0, self._animate)
 
         self.after(10, self._center)
 
@@ -943,9 +944,16 @@ class SplashScreen(ctk.CTkToplevel):
         y = (self.winfo_screenheight() - height) // 2
         self.geometry(f"{width}x{height}+{x}+{y}")
 
+    def _animate(self):
+        """Continuously animate the progress bar."""
+        self._progress_value = (self._progress_value + 0.02) % 1.0
+        self.progress.set(self._progress_value)
+        self._animate_job = self.after(20, self._animate)
+
     def close(self):
         """Stop animation and destroy splash."""
-        self.progress.stop()
+        if getattr(self, "_animate_job", None):
+            self.after_cancel(self._animate_job)
         self.destroy()
 
 

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -971,7 +971,10 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
             self._owns_root = True
         else:
             self._owns_root = False
-        self._root = master
+        # keep a reference to the hidden root window without shadowing
+        # tkinter's internal ``_root`` function used during widget
+        # initialization
+        self._root_win = master
 
         super().__init__(master)
         self.withdraw()
@@ -984,7 +987,7 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         self.columnconfigure(0, weight=1)
 
         # splash shown on the root so main window stays hidden
-        self.splash = SplashScreen(self._root)
+        self.splash = SplashScreen(self._root_win)
 
         # defer heavy initialization so splash becomes visible
         self._init_started = False
@@ -1079,7 +1082,7 @@ class ApplianceManagerWindow(ctk.CTkToplevel):
         self.destroy()
         if self._owns_root:
             try:
-                self._root.destroy()
+                self._root_win.destroy()
             except Exception:
                 pass
 

--- a/ApplianceManagerFrame.py
+++ b/ApplianceManagerFrame.py
@@ -928,19 +928,11 @@ class SplashScreen(ctk.CTkToplevel):
             row=1, column=0, pady=(0, 10)
         )
 
-        self.progress = ctk.CTkProgressBar(self, height=8)
+        self.progress = ctk.CTkProgressBar(self, height=8, mode="indeterminate")
         self.progress.grid(row=2, column=0, sticky="ew", padx=80, pady=(0, 60))
-        self.progress.set(0)
-        self._anim = None
-        self.after(0, self._animate)
+        self.progress.start()
 
         self.after(10, self._center)
-
-    def _animate(self):
-        """Animate progress bar for visual feedback."""
-        next_val = (self.progress.get() + 0.02) % 1.0
-        self.progress.set(next_val)
-        self._anim = self.after(30, self._animate)
 
     def _center(self):
         """Center splash on the screen."""
@@ -953,11 +945,10 @@ class SplashScreen(ctk.CTkToplevel):
 
     def close(self):
         """Stop animation and destroy splash."""
-        if self._anim:
-            try:
-                self.after_cancel(self._anim)
-            except Exception:
-                pass
+        try:
+            self.progress.stop()
+        except Exception:
+            pass
         self.destroy()
 
 


### PR DESCRIPTION
## Summary
- show splash screen and defer heavy init for appliance manager
- default VAT switch to 6% and recalc cart totals after removals
- close hidden root window when manager exits to avoid stray white window

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688df795ef3883208f9191197cb10a6d